### PR TITLE
Updated log signature to return an array of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ Runs action through `formatter` function, then calls the `logFunction`.
 ```js
     foo: {
       middleware: [
-        log({ formatter: action => `thar be an action yonder ${action}` }),
+        log({
+          formatter: action => [
+          'thar be an action yonder',
+          action
+        ]}),
       ],
     },
     // logs `thar be an action yonder { type: foo }`
 ```
+`formatter` should return an array of arguments to be applied to the `logFunction`.
 
 ### `swapTypes` object -> action -> decoratedAction
 Takes an object where keys are the types to swap, and values are the types to swap them with.

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,25 @@ export const decoratePayload = func => ({ payload, ...action }) =>
   ({ payload: func(payload), ...action });
 
 const defaultFormatter = ({ type, ...action }) =>
-  `${type} | payload: ${action.payload} meta: ${action.meta} errors: ${action.errors}`;
+  [
+    type,
+    '|',
+    'payload:', action.payload,
+    'meta:', action.meta,
+    'errors:', action.errors,
+  ];
 
-export const log = ({ formatter = defaultFormatter, logFunction = console.log }) =>
-  action => {
-    logFunction(formatter(action));
+export const log = (params = {}) => {
+  const {
+    formatter = defaultFormatter,
+    logFunction = console.log,
+  } = params;
+
+  return action => {
+    logFunction.apply(null, formatter(action));
     return action;
   };
+};
 
 export const swapTypes = typesToSwap => ({ type, ...action }) =>
   ({ type: typesToSwap[type] || type, ...action });

--- a/tests/middleware.js
+++ b/tests/middleware.js
@@ -84,7 +84,7 @@ describe('log', () => {
     const action = { type: 'foo' };
     let loggedMessage = '';
 
-    const formatter = JSON.stringify;
+    const formatter = action => [JSON.stringify(action)];
     const logFunction = message => { loggedMessage = message; };
     log({ logFunction, formatter })(action);
 

--- a/tests/middleware.js
+++ b/tests/middleware.js
@@ -90,7 +90,7 @@ describe('log', () => {
 
     expect(loggedMessage).to.equal(JSON.stringify(action));
   });
-})
+});
 
 describe('propCheck', () => {
   it('should not modify the action', () => {


### PR DESCRIPTION
## Description
`formatter` function now accepts an array of arguments to be applied to the `logFunction`